### PR TITLE
implement faster unit quaterion rotation

### DIFF
--- a/math/Quaterniond.cs
+++ b/math/Quaterniond.cs
@@ -112,6 +112,19 @@ namespace g3
                 v.x * (twoXZ - twoWY) + v.y * (twoYZ + twoWX) + v.z * (1 - (twoXX + twoYY))); ;
         }
 
+        /// <summary>
+        /// Works only for unit quaternion.
+        /// It uses the fact that (w^2 + xyz . xyz == 1) to simplify the product -- there xyz is a vector with (x, y, z) components and w is real part.
+        /// </summary>
+        /// <remarks>for derivation see https://fgiesen.wordpress.com/2019/02/09/rotating-a-single-vector-using-a-quaternion/</remarks>
+        public Vector3d Rotate(in Vector3d v)
+        {
+            // t = 2 * cross(q.xyz, v)
+            // v' = v + q.w * t + cross(q.xyz, t)
+            Vector3d xyz = new Vector3d(x, y, z);
+            Vector3d t = 2 * xyz.Cross(v);
+            return v + w * t + xyz.Cross(t);
+        }
 
         // these multiply quaternion by (1,0,0), (0,1,0), (0,0,1), respectively.
         // faster than full multiply, because of all the zeros

--- a/math/Quaternionf.cs
+++ b/math/Quaternionf.cs
@@ -118,7 +118,33 @@ namespace g3
                 v.x * (twoXZ - twoWY) + v.y * (twoYZ + twoWX) + v.z * (1 - (twoXX + twoYY))); ;
         }
 
+        /// <summary>
+        /// Works only if quaternion is unit.
+        /// It uses the fact that (w^2 + xyz . xyz == 1) to simplify the product -- there xyz is a vector with (x, y, z) components and w is real part.
+        /// </summary>
+        /// <remarks>for derivation see https://fgiesen.wordpress.com/2019/02/09/rotating-a-single-vector-using-a-quaternion/</remarks>
+        public Vector3f Rotate(in Vector3f v)
+        {
+            // t = 2 * cross(q.xyz, v)
+            // v' = v + q.w * t + cross(q.xyz, t)
+            Vector3f xyz = new Vector3f(x, y, z);
+            Vector3f t = 2 * xyz.Cross(v);
+            return v + w * t + xyz.Cross(t);
+        }
 
+        /// <summary>
+        /// Works only if quaternion is unit.
+        /// It uses the fact that (w^2 + xyz . xyz == 1) to simplify the product -- there xyz is a vector with (x, y, z) components and w is real part.
+        /// </summary>
+        /// <remarks>for derivation see https://fgiesen.wordpress.com/2019/02/09/rotating-a-single-vector-using-a-quaternion/</remarks>
+        public Vector3d Rotate(in Vector3d v)
+        {
+            // t = 2 * cross(q.xyz, v)
+            // v' = v + q.w * t + cross(q.xyz, t)
+            Vector3d xyz = new Vector3d(x, y, z);
+            Vector3d t = 2 * xyz.Cross(v);
+            return v + w * t + xyz.Cross(t);
+        }
 
         /// <summary> Inverse() * v </summary>
         public readonly Vector3f InverseMultiply(ref Vector3f v)


### PR DESCRIPTION
Somewhat faster unit-quaternion vector product for vector rotation (Rotation). The idea here is to use the fact that we rotate by a unit quaternion, that is `w^2  +  xyz . xyz == 1`. For detailed derivation see https://fgiesen.wordpress.com/2019/02/09/rotating-a-single-vector-using-a-quaternion/

INB4: yes, storing rotation matrix yields better performance, but the default `* `operator (QuaternionVectorProduct) is doing worse.

```
BenchmarkDotNet=v0.13.1, OS=ubuntu 20.04
Intel Core i5-7400 CPU 3.00GHz (Kaby Lake), 1 CPU, 4 logical and 4 physical cores
.NET SDK=5.0.402
  [Host]     : .NET Core 3.1.20 (CoreCLR 4.700.21.47003, CoreFX 4.700.21.47101), X64 RyuJIT
  DefaultJob : .NET Core 3.1.20 (CoreCLR 4.700.21.47003, CoreFX 4.700.21.47101), X64 RyuJIT


|                  Method |      Mean |     Error |    StdDev |       Min |       Max | Allocated |
|------------------------ |----------:|----------:|----------:|----------:|----------:|----------:|
| QuaternionVectorProduct | 10.925 ns | 0.0307 ns | 0.0272 ns | 10.885 ns | 10.964 ns |         - |
|                  Rotate |  9.329 ns | 0.0336 ns | 0.0298 ns |  9.257 ns |  9.360 ns |         - |

// * Hints *
Outliers
  Bench.QuaternionVectorProduct: Default -> 1 outlier  was  removed (13.69 ns)
  Bench.Rotate: Default                  -> 1 outlier  was  removed, 3 outliers were detected (11.15 ns, 11.18 ns, 11.29 ns)            
```