### PR TITLE
Add IImplicitFunction2d, IImplicitFunction2dWithBoundedDomain interfaces

### DIFF
--- a/implicit/Implicit2d.cs
+++ b/implicit/Implicit2d.cs
@@ -1,8 +1,24 @@
 using System;
-using System.Collections.Generic;
 
 namespace g3
 {
+	/// <summary>
+	/// Minimalist implicit function interface
+	/// </summary>
+	public interface IImplicitFunction2d
+	{
+		double Value(in Vector2d point);
+	}
+
+	/// <summary>
+	/// Bounded implicit function has a bounding box within which
+	/// the "interesting" part of the function is confined
+	/// </summary>
+	public interface IImplicitFunction2dWithBoundedDomain : IImplicitFunction2d
+	{
+		AxisAlignedBox2d Bounds { get; }
+	}
+
 	/// <summary>
 	/// Summary description for ImplicitField2D.
 	/// </summary>


### PR DESCRIPTION
We didn't have interfaces like `ImplicitFunction3d` for 2d-case. 
These interfaces are convenient for bilinear interpolation and functions defined on 2d space (like height map)