### PR TITLE
#3196 add type converter to allow parse colorf from string

### DIFF
--- a/color/Colorf.cs
+++ b/color/Colorf.cs
@@ -1,6 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
+using System.ComponentModel;
 
 #if G3_USING_UNITY
 using UnityEngine;
@@ -8,6 +7,7 @@ using UnityEngine;
 
 namespace g3
 {
+    [TypeConverter(typeof(StringToColorfConverter))]
     public struct Colorf : IComparable<Colorf>, IEquatable<Colorf>
     {
         public float r;
@@ -240,6 +240,11 @@ namespace g3
         public static implicit operator Colorf(Vector3f c)
         {
             return new Colorf(c.x, c.y, c.z, 1);
+        }
+
+        public static implicit operator Colorf(string hexColor)
+        {
+            return ColorBuilder.ParseHtmlColor(hexColor);
         }
 
 

--- a/color/ColorfBuilder.cs
+++ b/color/ColorfBuilder.cs
@@ -1,0 +1,58 @@
+﻿using System.Globalization;
+
+namespace g3
+{
+    public static class ColorBuilder
+    {
+        private static Colorf DefaultColor = new Colorf(0f);
+
+        public static Colorf ParseHtmlColor(string hexColor)
+        {
+            if (hexColor == null || hexColor.Length < 7 || !hexColor.StartsWith("#"))
+            {
+                return DefaultColor;
+            }
+            string hex = hexColor.Replace("#", string.Empty);
+            NumberStyles h = NumberStyles.HexNumber;
+
+            int r = int.Parse(hex.Substring(0, 2), h);
+            int g = int.Parse(hex.Substring(2, 2), h);
+            int b = int.Parse(hex.Substring(4, 2), h);
+            int a = 255;
+
+            if (hex.Length == 8)
+            {
+                a = int.Parse(hex.Substring(6, 2), h);
+            }
+
+            return new Colorf(r, g, b, a);
+        }
+
+        public static bool TryParseHtmlString(string hexColor, out Colorf color)
+        {
+            try
+            {
+                string hex = hexColor.Replace("#", string.Empty);
+                NumberStyles h = NumberStyles.HexNumber;
+
+                int r = int.Parse(hex.Substring(0, 2), h);
+                int g = int.Parse(hex.Substring(2, 2), h);
+                int b = int.Parse(hex.Substring(4, 2), h);
+                int a = 255;
+
+                if (hex.Length == 8)
+                {
+                    a = int.Parse(hex.Substring(6, 2), h);
+                }
+
+                color = new Colorf(r, g, b, a);
+                return true;
+            }
+            catch (System.Exception)
+            {
+                color = DefaultColor;
+                return false;
+            }
+        }
+    }
+}

--- a/color/StringToColorfConverter.cs
+++ b/color/StringToColorfConverter.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.ComponentModel;
+using System.Globalization;
+
+namespace g3
+{
+    public class StringToColorfConverter : TypeConverter
+    {
+        public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+        {
+            return sourceType == typeof(string);
+        }
+
+        public override bool CanConvertTo(ITypeDescriptorContext context, Type destinationType)
+        {
+            return destinationType == typeof(Colorf);
+        }
+
+        public override object ConvertTo(ITypeDescriptorContext context, CultureInfo culture, object value, Type destinationType)
+        {
+            return value?.ToString() ?? default(Colorf).ToString();
+        }
+
+        public override object ConvertFrom(ITypeDescriptorContext context, CultureInfo culture, object value)
+        {
+            return ColorBuilder.ParseHtmlColor(value?.ToString());
+        }
+    }
+}

--- a/geometry3Sharp.csproj
+++ b/geometry3Sharp.csproj
@@ -50,9 +50,11 @@
     <Compile Include="approximation\OrthogonalPlaneFit3.cs" />
     <Compile Include="color\Colorb.cs" />
     <Compile Include="color\Colorf.cs" />
+    <Compile Include="color\ColorfBuilder.cs" />
     <Compile Include="color\ColorHSV.cs" />
     <Compile Include="color\ColorMap.cs" />
     <Compile Include="color\ColorMixer.cs" />
+    <Compile Include="color\StringToColorfConverter.cs" />
     <Compile Include="comp_geom\GraphCells2d.cs" />
     <Compile Include="comp_geom\GraphSplitter2d.cs" />
     <Compile Include="comp_geom\SphericalFibonacciPointSet.cs" />


### PR DESCRIPTION


Чтобы иметь возможность использовать hex цвета в конфигурации, нам надо иметь возможность конвертировать строки в Colorf, собственно.

Из-за того, как работает чтение конфигурации в дотнете, мы не можем контролировать процесс десериализации json конфига в инстанс класса напрямую.

Чтение конфигурации в дотнете разбито на две части:

    Использование провайдера для чтения конфига из произвольного источника в словарь ключ:значение.
    Использование внутренних дотнент вещей для инстанциации классов конфигурации.

И если первую часть мы выбираем сами (в нашем случае через вызов метода .AddJsonFile()), то вторая не настолько гибка и единственный способ повлиять на то, как будут сопоставляться строковые ключи из вышеупомянутого словаря на поля классов конфигураций - использовать TypeConverter.

Для того чтобы разобраться как эта конвертация работает, мне пришлось вытащить исходники System.ComponentModel, подебажить и тогда я догадался, что конвертер надо вешать не на свойство с типом Colorf, а на сам тип ColorF. Дело тут в том, что код в дотнете смотрит на атрибуты типа а не на атрибуты свойства класса, на которое будет мапить значение.

Поэтому пришлось код атрибута и парсер перенести в g3.

Если есть идеи получше - с удовольствием выслушаю
