### PR TITLE
#4974 Add break to MinimalHoleFill

### DIFF
--- a/mesh/RemesherPro.cs
+++ b/mesh/RemesherPro.cs
@@ -130,7 +130,7 @@ namespace gs
             var saveMode = this.ProjectionMode;
             for (int k = 0; k < nMaxIterations - 1; ++k) {
                 if (Cancelled())
-                    break;
+                    return;
                 ProjectionMode = (k % 2 == 0) ? TargetProjectionMode.NoProjection : saveMode;
                 RemeshIteration();
             }

--- a/mesh_ops/MinimalHoleFill.cs
+++ b/mesh_ops/MinimalHoleFill.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using g3;
 
 namespace gs
@@ -48,7 +49,7 @@ namespace gs
 
         double[] curvatures;
 
-        public bool Apply()
+        public bool Apply(ProgressCancel? progressCancel = null)
         {
             // do a simple fill
             SimpleHoleFiller simplefill = new SimpleHoleFiller(Mesh, FillLoop);
@@ -100,6 +101,7 @@ namespace gs
 
             // remesh up to target edge length, ideally gives us some triangles to work with
             RemesherPro remesh1 = new RemesherPro(fillmesh);
+            remesh1.Progress = progressCancel;
             remesh1.SmoothSpeedT = 1.0;
             MeshConstraintUtil.FixAllBoundaryEdges(remesh1);
             //remesh1.SetTargetEdgeLength(remesh_target_len / 2);       // would this speed things up? on large regions?
@@ -119,11 +121,15 @@ namespace gs
             int zero_collapse_passes = 0;
             int collapse_passes = 0;
             while (collapse_passes++ < 20 && zero_collapse_passes < 2) {
+                if (progressCancel != null && progressCancel.Cancelled())
+                    return false;
 
                 // collapse pass
                 int NE = fillmesh.MaxEdgeID;
                 int collapses = 0;
                 for (int ei = 0; ei < NE; ++ei) {
+                    if (progressCancel != null && progressCancel.Cancelled())
+                        return false;
                     if (fillmesh.IsEdge(ei) == false || fillmesh.IsBoundaryEdge(ei))
                         continue;
                     Index2i ev = fillmesh.GetEdgeV(ei);
@@ -149,6 +155,8 @@ namespace gs
                 NE = fillmesh.MaxEdgeID;
                 Vector3d n1, n2, on1, on2;
                 for (int ei = 0; ei < NE; ++ei) {
+                    if (progressCancel != null && progressCancel.Cancelled())
+                        return false;
                     if (fillmesh.IsEdge(ei) == false || fillmesh.IsBoundaryEdge(ei))
                         continue;
                     bool do_flip = false;

--- a/mesh_ops/MinimalHoleFill.cs
+++ b/mesh_ops/MinimalHoleFill.cs
@@ -75,7 +75,10 @@ namespace gs
             boundaryv = new HashSet<int>(MeshIterators.BoundaryEdgeVertices(fillmesh));
             exterior_angle_sums = new Dictionary<int, double>();
             if (IgnoreBoundaryTriangles == false) {
-                foreach (int sub_vid in boundaryv) {
+                foreach (int sub_vid in boundaryv)
+                {
+                    if (progressCancel != null && progressCancel.Cancelled())
+                        return false;
                     double angle_sum = 0;
                     int base_vid = regionop.Region.MapVertexToBaseMesh(sub_vid);
                     foreach (int tid in regionop.BaseMesh.VtxTrianglesItr(base_vid)) {
@@ -107,7 +110,8 @@ namespace gs
             //remesh1.SetTargetEdgeLength(remesh_target_len / 2);       // would this speed things up? on large regions?
             //remesh1.FastestRemesh();
             remesh1.SetTargetEdgeLength(remesh_target_len);
-            remesh1.FastestRemesh();
+            if (!remesh1.FastestRemesh())
+                return false;
 
             /*
              * first round: collapse to minimal mesh, while flipping to try to 
@@ -216,6 +220,8 @@ namespace gs
             while ( flatter_passes++ < 40 && zero_flips_passes < 2 && remaining_edges.Count() > 0 && DO_FLATTER_PASS) {
                 zero_flips_passes++;
                 foreach (int ei in remaining_edges) {
+                    if (progressCancel != null && progressCancel.Cancelled())
+                        return false;
                     if (fillmesh.IsBoundaryEdge(ei))
                         continue;
 
@@ -266,6 +272,8 @@ namespace gs
                  */
                 while (curvature_passes++ < 40 && remaining_edges.Count() > 0 && DO_CURVATURE_PASS) {
                     foreach (int ei in remaining_edges) {
+                        if (progressCancel != null && progressCancel.Cancelled())
+                            return false;
                         if (fillmesh.IsBoundaryEdge(ei))
                             continue;
 
@@ -316,6 +324,8 @@ namespace gs
                 while (remaining_edges.Count() > 0 && area_passes < 20) {
                     area_passes++;
                     foreach (int ei in remaining_edges) {
+                        if (progressCancel != null && progressCancel.Cancelled())
+                            return false;
                         if (fillmesh.IsBoundaryEdge(ei))
                             continue;
 


### PR DESCRIPTION
## Problem

Sometimes, when a mesh has some non-manifold zone, the `MinimalHoleFill` goes into an infinite loop. It's not really, but 10 minutes must be enough to process

## Solution

Temporary advance the class with the progress canceller to make the cancellation possible in case of a timeout. Later, some algorithms improvements may be introduced, but now it's not the time for such a venture