### PR TITLE
fixed removing vertices (DMesh3.RemoveVertex() method)

### DIFF
--- a/mesh/DMesh3.cs
+++ b/mesh/DMesh3.cs
@@ -1658,7 +1658,8 @@ namespace g3
 
 
         /// <summary>
-        /// iterate over triangle IDs of vertex one-ring
+        /// iterate over triangle IDs of vertex one-ring.
+        /// NOTE: it can miss triangles on Non-Manifold mesh, see GetVtxTriangles(..., bUseOrientation: false);
         /// </summary>
 		public IEnumerable<int> VtxTrianglesItr(int vID) {
 			if ( IsVertex(vID) ) {

--- a/mesh/DMesh3_edge_operators.cs
+++ b/mesh/DMesh3_edge_operators.cs
@@ -76,6 +76,21 @@ namespace g3
                     if (result != MeshResult.Ok)
                         return result;
                 }
+
+                // above we enumerated adjacent triangles in mode [bUseOrientation: false], which is fast, but may miss triangles in case mesh structure in invalid.
+                // here we do additional attempt to find the invalid triangles.
+                // for example: the Invalid triangle may not have one of its Edges assigned,
+                // which supposedly happens when Three (or more) triangles lay on a single pair of vertices, because DMesh3 supposes only 2 triangles per edge, and a single edge per vertex pair.
+                if (vertices_refcount.refCount(vID) != 1)
+                {
+                    tris.Clear();
+                    GetVtxTriangles(vID, tris, bUseOrientation: false); // use extensive triangles search, which is robust on invalid meshes
+                    foreach (int tid in tris) {
+                        MeshResult result = RemoveTriangle(tid, false, bPreserveManifold);
+                        if (result != MeshResult.Ok)
+                            return result;
+                    }
+                }
             }
 
             if ( vertices_refcount.refCount(vID) != 1)

--- a/mesh/DMesh3_edge_operators.cs
+++ b/mesh/DMesh3_edge_operators.cs
@@ -77,7 +77,7 @@ namespace g3
                         return result;
                 }
 
-                // above we enumerated adjacent triangles in mode [bUseOrientation: false], which is fast, but may miss triangles in case mesh structure in invalid.
+                // above we enumerated adjacent triangles in mode [bUseOrientation: true], which is fast, but may miss triangles in case mesh structure in invalid.
                 // here we do additional attempt to find the invalid triangles.
                 // for example: the Invalid triangle may not have one of its Edges assigned,
                 // which supposedly happens when Three (or more) triangles lay on a single pair of vertices, because DMesh3 supposes only 2 triangles per edge, and a single edge per vertex pair.


### PR DESCRIPTION
fixed removing vertices (DMesh3.RemoveVertex() method) at invalid topology (bowtie vertices can cause Non-Manifold topology, not supported by DMesh3 structure)