### PR TITLE
Add clamp-like behavoiur when the parameter is not provided

### DIFF
--- a/spatial/PointSetHashtable.cs
+++ b/spatial/PointSetHashtable.cs
@@ -13,7 +13,7 @@ namespace gs
 		ShiftGridIndexer3 indexF;
 
 		Vector3d Origin;
-		double CellSize;
+		public double CellSize { get; private set; }
 
 		public PointSetHashtable(IPointSet points)
 		{


### PR DESCRIPTION
## Problem

The requests fail with exception when `MergeDistance` is larger than `CellSize`. 

## Solution

In most of cases, we don't mind if the requested radius is smaller than `ZeroToleranceF`.

That's why if the `MergeDistance` parameters is not set, we can stick to the `CellSize` value without any consequences.

But we don't change the behaviour if somebody requested a specific merger configuration.