### PR TITLE
Remove redundant parallelism

### DIFF
--- a/core/DVector.cs
+++ b/core/DVector.cs
@@ -41,9 +41,9 @@ namespace g3
             }
         }
 
-        public DVector(T[] data)
+        public DVector(T[] data, int? count = null)
         {
-            Initialize(data);
+            Initialize(data, count);
         }
 
         public DVector(IEnumerable<T> init)
@@ -279,9 +279,10 @@ namespace g3
 
 
 
-        public void Initialize(T[] data)
+        public void Initialize(T[] data, int? count = null)
         {
-            int blocks = data.Length / nBlockSize;
+            int length = count ?? data.Length;
+            int blocks = length / nBlockSize;
             Blocks = new List<T[]>();
             int ai = 0;
             for (int i = 0; i < blocks; ++i) {
@@ -290,7 +291,7 @@ namespace g3
                 Blocks.Add(block);
                 ai += nBlockSize;
             }
-            iCurBlockUsed = data.Length - ai;
+            iCurBlockUsed = length - ai;
             if (iCurBlockUsed != 0) {
                 T[] last = new T[nBlockSize];
                 Array.Copy(data, ai, last, 0, iCurBlockUsed);

--- a/core/Util.cs
+++ b/core/Util.cs
@@ -245,7 +245,7 @@ namespace g3
             StandardMeshWriter.WriteFile(sPath, new List<WriteMesh>() { new WriteMesh(mesh) }, options);
         }
 
-        public static void WriteDebugMeshAndMarkers(IMesh mesh, List<Vector3d> Markers, string sPath, int maxDegreeOfParallelism)
+        public static void WriteDebugMeshAndMarkers(IMesh mesh, List<Vector3d> Markers, string sPath)
         {
             WriteOptions options = WriteOptions.Defaults;
             options.bWriteGroups = true;
@@ -254,7 +254,7 @@ namespace g3
             foreach ( Vector3d v in Markers ) {
                 TrivialBox3Generator boxgen = new TrivialBox3Generator();
                 boxgen.Box = new Box3d(v, size * Vector3d.One);
-                boxgen.Generate(maxDegreeOfParallelism);
+                boxgen.Generate();
                 DMesh3 m = new DMesh3();
                 boxgen.MakeMesh(m);
                 meshes.Add(new WriteMesh(m));

--- a/geometry3Sharp.csproj
+++ b/geometry3Sharp.csproj
@@ -44,5 +44,9 @@
     <EmbeddedResource Remove="test\**" />
     <None Remove="test\**" />
   </ItemGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="System.Buffers" Version="4.5.1" />
+  </ItemGroup>
 
 </Project>

--- a/math/MathUtil.cs
+++ b/math/MathUtil.cs
@@ -454,16 +454,24 @@ namespace g3
             vCross.Normalize();
             return vCross;
         }
-        public static Vector3d Normal(Vector3d v1, Vector3d v2, Vector3d v3) {
-            return Normal(ref v1, ref v2, ref v3);
+
+        public static Vector3d Normal(Vector3d v1, Vector3d v2, Vector3d v3)
+        {
+            Vector3d edge1 = v2 - v1;
+            Vector3d edge2 = v3 - v2;
+            edge1.Normalize();
+            edge2.Normalize();
+            Vector3d vCross = edge1.Cross(edge2);
+            vCross.Normalize();
+            return vCross;
         }
 
 
-		/// <summary>
-		/// compute vector in direction of triangle normal (cross-product). No normalization.
-		/// </summary>
-		/// <returns>The normal direction.</returns>
-		public static Vector3d FastNormalDirection(ref Vector3d v1, ref Vector3d v2, ref Vector3d v3)
+        /// <summary>
+        /// compute vector in direction of triangle normal (cross-product). No normalization.
+        /// </summary>
+        /// <returns>The normal direction.</returns>
+        public static Vector3d FastNormalDirection(ref Vector3d v1, ref Vector3d v2, ref Vector3d v3)
 		{
 			Vector3d edge1 = v2 - v1;
 			Vector3d edge2 = v3 - v1;

--- a/math/MathUtil.cs
+++ b/math/MathUtil.cs
@@ -448,8 +448,6 @@ namespace g3
         public static Vector3d Normal(ref Vector3d v1, ref Vector3d v2, ref Vector3d v3) {
             Vector3d edge1 = v2 - v1;
             Vector3d edge2 = v3 - v2;
-            edge1.Normalize();
-            edge2.Normalize();
             Vector3d vCross = edge1.Cross(edge2);
             vCross.Normalize();
             return vCross;
@@ -459,8 +457,6 @@ namespace g3
         {
             Vector3d edge1 = v2 - v1;
             Vector3d edge2 = v3 - v2;
-            edge1.Normalize();
-            edge2.Normalize();
             Vector3d vCross = edge1.Cross(edge2);
             vCross.Normalize();
             return vCross;

--- a/mesh/MeshEditor.cs
+++ b/mesh/MeshEditor.cs
@@ -866,84 +866,84 @@ namespace g3
 
 
 
-        public void AppendBox(Frame3f frame, float size, int maxDegreeOfParallelism)
+        public void AppendBox(Frame3f frame, float size)
         {
-            AppendBox(frame, size * Vector3f.One, maxDegreeOfParallelism);
+            AppendBox(frame, size * Vector3f.One);
         }
-        public void AppendBox(Frame3f frame, Vector3f size, int maxDegreeOfParallelism)
+        public void AppendBox(Frame3f frame, Vector3f size)
         {
-            AppendBox(frame, size, Colorf.White, maxDegreeOfParallelism);
+            AppendBox(frame, size, Colorf.White);
         }
-        public void AppendBox(Frame3f frame, Vector3f size, Colorf color, int maxDegreeOfParallelism)
+        public void AppendBox(Frame3f frame, Vector3f size, Colorf color)
         {
             TrivialBox3Generator boxgen = new TrivialBox3Generator() {
                 Box = new Box3d(frame, size),
                 NoSharedVertices = false
             };
-            boxgen.Generate(maxDegreeOfParallelism);
+            boxgen.Generate();
             DMesh3 mesh = new DMesh3();
             boxgen.MakeMesh(mesh);
             if (Mesh.HasVertexColors)
                 mesh.EnableVertexColors(color);
             AppendMesh(mesh, Mesh.AllocateTriangleGroup());
         }
-        public void AppendLine(Segment3d seg, float size, int maxDegreeOfParallelism)
+        public void AppendLine(Segment3d seg, float size)
         {
             Frame3f f = new Frame3f(seg.Center);
             f.AlignAxis(2, (Vector3f)seg.Direction);
-            AppendBox(f, new Vector3f(size, size, seg.Extent), maxDegreeOfParallelism);
+            AppendBox(f, new Vector3f(size, size, seg.Extent));
         }
-        public void AppendLine(Segment3d seg, float size, Colorf color, int maxDegreeOfParallelism)
+        public void AppendLine(Segment3d seg, float size, Colorf color)
         {
             Frame3f f = new Frame3f(seg.Center);
             f.AlignAxis(2, (Vector3f)seg.Direction);
-            AppendBox(f, new Vector3f(size, size, seg.Extent), color, maxDegreeOfParallelism);
+            AppendBox(f, new Vector3f(size, size, seg.Extent), color);
         }
-        public static void AppendBox(DMesh3 mesh, Vector3d pos, float size, int maxDegreeOfParallelism)
+        public static void AppendBox(DMesh3 mesh, Vector3d pos, float size)
         {
             MeshEditor editor = new MeshEditor(mesh);
-            editor.AppendBox(new Frame3f(pos), size, maxDegreeOfParallelism);
+            editor.AppendBox(new Frame3f(pos), size);
         }
-        public static void AppendBox(DMesh3 mesh, Vector3d pos, float size, Colorf color, int maxDegreeOfParallelism)
+        public static void AppendBox(DMesh3 mesh, Vector3d pos, float size, Colorf color)
         {
             MeshEditor editor = new MeshEditor(mesh);
-            editor.AppendBox(new Frame3f(pos), size*Vector3f.One, color, maxDegreeOfParallelism);
+            editor.AppendBox(new Frame3f(pos), size*Vector3f.One, color);
         }
-        public static void AppendBox(DMesh3 mesh, Vector3d pos, Vector3d normal, float size, int maxDegreeOfParallelism)
+        public static void AppendBox(DMesh3 mesh, Vector3d pos, Vector3d normal, float size)
         {
             MeshEditor editor = new MeshEditor(mesh);
-            editor.AppendBox(new Frame3f(pos, normal), size, maxDegreeOfParallelism);
+            editor.AppendBox(new Frame3f(pos, normal), size);
         }
-        public static void AppendBox(DMesh3 mesh, Vector3d pos, Vector3d normal, float size, Colorf color, int maxDegreeOfParallelism)
+        public static void AppendBox(DMesh3 mesh, Vector3d pos, Vector3d normal, float size, Colorf color)
         {
             MeshEditor editor = new MeshEditor(mesh);
-            editor.AppendBox(new Frame3f(pos, normal), size*Vector3f.One, color, maxDegreeOfParallelism);
+            editor.AppendBox(new Frame3f(pos, normal), size*Vector3f.One, color);
         }
-        public static void AppendBox(DMesh3 mesh, Frame3f frame, Vector3f size, Colorf color, int maxDegreeOfParallelism)
+        public static void AppendBox(DMesh3 mesh, Frame3f frame, Vector3f size, Colorf color)
         {
             MeshEditor editor = new MeshEditor(mesh);
-            editor.AppendBox(frame, size, color, maxDegreeOfParallelism);
+            editor.AppendBox(frame, size, color);
         }
 
-        public static void AppendLine(DMesh3 mesh, Segment3d seg, float size, int maxDegreeOfParallelism)
+        public static void AppendLine(DMesh3 mesh, Segment3d seg, float size)
         {
             Frame3f f = new Frame3f(seg.Center);
             f.AlignAxis(2, (Vector3f)seg.Direction);
             MeshEditor editor = new MeshEditor(mesh);
-            editor.AppendBox(f, new Vector3f(size, size, seg.Extent), maxDegreeOfParallelism);
+            editor.AppendBox(f, new Vector3f(size, size, seg.Extent));
         }
 
 
 
 
-        public void AppendPathSolid(IEnumerable<Vector3d> vertices, double radius, Colorf color, int maxDegreeOfParallelism)
+        public void AppendPathSolid(IEnumerable<Vector3d> vertices, double radius, Colorf color)
         {
             TubeGenerator tubegen = new TubeGenerator() {
                 Vertices = new List<Vector3d>(vertices),
                 Polygon = Polygon2d.MakeCircle(radius, 6),
                 NoSharedVertices = false
             };
-            DMesh3 mesh = tubegen.Generate(maxDegreeOfParallelism).MakeDMesh();
+            DMesh3 mesh = tubegen.Generate().MakeDMesh();
             if (Mesh.HasVertexColors)
                 mesh.EnableVertexColors(color);
             AppendMesh(mesh, Mesh.AllocateTriangleGroup());

--- a/mesh/MeshNormals.cs
+++ b/mesh/MeshNormals.cs
@@ -1,13 +1,13 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
+﻿#nullable enable
+
+using System;
+using System.Buffers;
 
 namespace g3
 {
     public class MeshNormals
     {
-        public IMesh Mesh;
+        public DMesh3 Mesh;
         public DVector<Vector3d> Normals;
 
         /// <summary>
@@ -16,8 +16,6 @@ namespace g3
         /// </summary>
         public Func<int, Vector3d> VertexF;
 
-
-
         public enum NormalsTypes
         {
             Vertex_OneRingFaceAverage_AreaWeighted
@@ -25,7 +23,7 @@ namespace g3
         public NormalsTypes NormalType;
 
 
-        public MeshNormals(IMesh mesh, NormalsTypes eType = NormalsTypes.Vertex_OneRingFaceAverage_AreaWeighted)
+        public MeshNormals(DMesh3 mesh, NormalsTypes eType = NormalsTypes.Vertex_OneRingFaceAverage_AreaWeighted)
         {
             Mesh = mesh;
             NormalType = eType;
@@ -34,11 +32,18 @@ namespace g3
         }
 
 
-        public void Compute(int maxDegreeOfParallelism)
+        public void Compute(ArrayPool<Vector3f>? arrayPool = null)
         {
-            Compute_FaceAvg_AreaWeighted(maxDegreeOfParallelism);
+            arrayPool ??= ArrayPool<Vector3f>.Shared;
+            Vector3f[] normalsArray = arrayPool.Rent(Mesh.MaxVertexID);
+            QuickComputeToArray(Mesh, normalsArray);
+            int NV = Mesh.MaxVertexID;
+            if (NV != Normals.size)
+                Normals.resize(NV);
+            for (int vid = 0; vid < NV; ++vid)
+                Normals[vid] = (Vector3d)normalsArray[vid];
+            arrayPool.Return(normalsArray);
         }
-
 
         public Vector3d this[int vid] {
             get { return Normals[vid]; }
@@ -59,51 +64,48 @@ namespace g3
             }
         }
 
-
-
-
-        // TODO: parallel version, cache tri normals
-        void Compute_FaceAvg_AreaWeighted(int maxDegreeOfParallelism)
+        public static void QuickCompute(DMesh3 mesh, ArrayPool<Vector3f>? arrayPool = null)
         {
-            int NV = Mesh.MaxVertexID;
-            if ( NV != Normals.size ) 
-                Normals.resize(NV);
-            for (int i = 0; i < NV; ++i)
-                Normals[i] = Vector3d.Zero;
-
-            SpinLock Normals_lock = new SpinLock();
-
-            gParallel.ForEach(Mesh.TriangleIndices(), (ti) => {
-                Index3i tri = Mesh.GetTriangle(ti);
-                Vector3d va = Mesh.GetVertex(tri.a);
-                Vector3d vb = Mesh.GetVertex(tri.b);
-                Vector3d vc = Mesh.GetVertex(tri.c);
-                Vector3d N = MathUtil.Normal(ref va, ref vb, ref vc);
-                double a = MathUtil.Area(ref va, ref vb, ref vc);
-                bool taken = false;
-                Normals_lock.Enter(ref taken);
-                Normals[tri.a] += a * N;
-                Normals[tri.b] += a * N;
-                Normals[tri.c] += a * N;
-                Normals_lock.Exit();
-            }, maxDegreeOfParallelism);
-
-            gParallel.BlockStartEnd(0, NV - 1, (vi_start, vi_end) => {
-                for (int vi = vi_start; vi <= vi_end; vi++) {
-                    if (Normals[vi].LengthSquared > MathUtil.ZeroTolerancef)
-                        Normals[vi] = Normals[vi].Normalized;
-                }
-            }, maxDegreeOfParallelism);
+            arrayPool ??= ArrayPool<Vector3f>.Shared;
+            Vector3f[] normalsArray = arrayPool.Rent(mesh.MaxVertexID);
+            QuickComputeToArray(mesh, normalsArray);
+            // Write to mesh
+            mesh.EnableVertexNormals(Vector3f.Zero);
+            for (int vid = 0; vid < mesh.MaxVertexID; vid++)
+            {
+                if (!mesh.IsVertex(vid))
+                    continue;
+                mesh.SetVertexNormal(vid, normalsArray[vid]);
+            }
+            arrayPool.Return(normalsArray);
         }
 
-
-
-
-        public static void QuickCompute(DMesh3 mesh, int maxDegreeOfParallelism)
+        private static void QuickComputeToArray(DMesh3 mesh, Vector3f[] normalsArray)
         {
-            MeshNormals normals = new MeshNormals(mesh);
-            normals.Compute(maxDegreeOfParallelism);
-            normals.CopyTo(mesh);
+            for (int vid = 0; vid < mesh.MaxVertexID; vid++)
+                normalsArray[vid] = Vector3f.Zero;
+            for (int tid = 0; tid < mesh.MaxTriangleID; tid++)
+            {
+                if (!mesh.IsTriangle(tid))
+                    continue;
+                Index3i triangle = mesh.GetTriangle(tid);
+                Vector3d vertexA = mesh.GetVertexUnsafe(triangle.a);
+                Vector3d vertexB = mesh.GetVertexUnsafe(triangle.b);
+                Vector3d vertexC = mesh.GetVertexUnsafe(triangle.c);
+                Vector3d triangleNormal = MathUtil.Normal(vertexA, vertexB, vertexC);
+                double triangleArea = MathUtil.Area(vertexA, vertexB, vertexC);
+                Vector3f areaNormalMultiplication = (Vector3f)(triangleArea * triangleNormal);
+                normalsArray[triangle.a] += areaNormalMultiplication;
+                normalsArray[triangle.b] += areaNormalMultiplication;
+                normalsArray[triangle.c] += areaNormalMultiplication;
+            }
+            // Normalize array
+            for (int vid = 0; vid < mesh.MaxVertexID; vid++)
+            {
+                Vector3f vertexNormal = normalsArray[vid];
+                if (vertexNormal.LengthSquared > MathUtil.ZeroTolerancef)
+                    normalsArray[vid] = vertexNormal.Normalized;
+            }
         }
 
 

--- a/mesh_generators/ArrowGenerators.cs
+++ b/mesh_generators/ArrowGenerators.cs
@@ -14,7 +14,7 @@ namespace g3
         public float TipRadius = 0.0f;
         public float HeadLength = 0.5f;
 
-        override public MeshGenerator Generate(int maxDegreeOfParallelism)
+        override public MeshGenerator Generate()
         {
             Sections = new CircularSection[4];
             Sections[0] = new CircularSection(StickRadius, 0.0f);
@@ -24,7 +24,7 @@ namespace g3
 
             Capped = true;
             NoSharedVertices = true;
-            base.Generate(maxDegreeOfParallelism);
+            base.Generate();
 
             return this;
         }

--- a/mesh_generators/BoxGenerators.cs
+++ b/mesh_generators/BoxGenerators.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 
 namespace g3
 {
@@ -12,7 +11,7 @@ namespace g3
         public Box3d Box = Box3d.UnitZeroCentered;
         public bool NoSharedVertices = false;
 
-        public override MeshGenerator Generate(int maxDegreeOfParallelism)
+        public override MeshGenerator Generate()
         {
             vertices = new VectorArray3d((NoSharedVertices) ? (4 * 6) : 8);
             uv = new VectorArray2f(vertices.Count);
@@ -74,7 +73,7 @@ namespace g3
         public int EdgeVertices = 8;
         public bool NoSharedVertices = false;
 
-        public override MeshGenerator Generate(int maxDegreeOfParallelism)
+        public override MeshGenerator Generate()
         {
             int N = (EdgeVertices > 1) ? EdgeVertices : 2;
             int Nm2 = N - 2;

--- a/mesh_generators/CylinderGenerators.cs
+++ b/mesh_generators/CylinderGenerators.cs
@@ -19,7 +19,7 @@ namespace g3
         // last panel will not have UVs going from 1 to 0
         public bool NoSharedVertices = false;
 
-        override public MeshGenerator Generate(int maxDegreeOfParallelism)
+        override public MeshGenerator Generate()
         {
             bool bClosed = ((EndAngleDeg - StartAngleDeg) > 359.99f);
             int nRingSize = (NoSharedVertices && bClosed) ? Slices + 1 : Slices;
@@ -81,7 +81,7 @@ namespace g3
         // set to true if you are going to texture this cylinder or want sharp edges
         public bool NoSharedVertices = false;
 
-        override public MeshGenerator Generate(int maxDegreeOfParallelism)
+        override public MeshGenerator Generate()
         {
             bool bClosed = ((EndAngleDeg - StartAngleDeg) > 359.99f);
             int nRingSize = (NoSharedVertices && bClosed) ? Slices + 1 : Slices;
@@ -218,7 +218,7 @@ namespace g3
         public bool NoSharedVertices = false;
 
 
-        override public MeshGenerator Generate(int maxDegreeOfParallelism)
+        override public MeshGenerator Generate()
         {
             bool bClosed = ((EndAngleDeg - StartAngleDeg) > 359.99f);
             int nRingSize = (NoSharedVertices && bClosed) ? Slices + 1 : Slices;
@@ -333,7 +333,7 @@ namespace g3
         public int startCapCenterIndex = -1;
         public int endCapCenterIndex = -1;
 
-        override public MeshGenerator Generate(int maxDegreeOfParallelism)
+        override public MeshGenerator Generate()
         {
             int nRings = (NoSharedVertices) ? 2 * (Sections.Length-1) : Sections.Length;
             int nRingSize = (NoSharedVertices) ? Slices + 1 : Slices;

--- a/mesh_generators/DiscGenerators.cs
+++ b/mesh_generators/DiscGenerators.cs
@@ -13,7 +13,7 @@ namespace g3
         public float EndAngleDeg = 360.0f;
         public int Slices = 32;
 
-        override public MeshGenerator Generate(int maxDegreeOfParallelism)
+        override public MeshGenerator Generate()
         {
             vertices = new VectorArray3d(Slices + 1);
             uv = new VectorArray2f(Slices + 1);
@@ -64,7 +64,7 @@ namespace g3
         public float EndAngleDeg = 360.0f;
         public int Slices = 32;
 
-        override public MeshGenerator Generate(int maxDegreeOfParallelism)
+        override public MeshGenerator Generate()
         {
             vertices = new VectorArray3d(2*Slices);
             uv = new VectorArray2f(2*Slices);

--- a/mesh_generators/GenCylGenerators.cs
+++ b/mesh_generators/GenCylGenerators.cs
@@ -74,7 +74,7 @@ namespace g3
 
 
 
-        override public MeshGenerator Generate(int maxDegreeOfParallelism)
+        override public MeshGenerator Generate()
         {
             if (Polygon == null)
                 Polygon = Polygon2d.MakeCircle(1.0f, 8);

--- a/mesh_generators/MeshGenerators.cs
+++ b/mesh_generators/MeshGenerators.cs
@@ -19,7 +19,7 @@ namespace g3
 
 
 
-        abstract public MeshGenerator Generate(int maxDegreeOfParallelism);
+        abstract public MeshGenerator Generate();
 
 
         public virtual void MakeMesh(SimpleMesh m)

--- a/mesh_generators/PlaneGenerators.cs
+++ b/mesh_generators/PlaneGenerators.cs
@@ -37,7 +37,7 @@ namespace g3
             return v;
         }
 
-        override public MeshGenerator Generate(int maxDegreeOfParallelism)
+        override public MeshGenerator Generate()
         {
             if (MathUtil.InRange(IndicesMap.a, 1, 3) == false || MathUtil.InRange(IndicesMap.b, 1, 3) == false)
                 throw new Exception("TrivialRectGenerator: Invalid IndicesMap!");
@@ -106,7 +106,7 @@ namespace g3
     {
         public int EdgeVertices = 8;
 
-        override public MeshGenerator Generate(int maxDegreeOfParallelism)
+        override public MeshGenerator Generate()
         {
             if (MathUtil.InRange(IndicesMap.a, 1, 3) == false || MathUtil.InRange(IndicesMap.b, 1, 3) == false)
                 throw new Exception("GriddedRectGenerator: Invalid IndicesMap!");
@@ -227,7 +227,7 @@ namespace g3
         // order is [inner_corner, outer_1, outer_2]
         static int[] corner_spans = new int[] { 0, 11, 4,   1, 5, 6,   2, 7, 8,   3, 9, 10 };
 
-        override public MeshGenerator Generate(int maxDegreeOfParallelism)
+        override public MeshGenerator Generate()
         {
             int corner_v = 0, corner_t = 0;
             for (int k = 0; k < 4; ++k) {

--- a/mesh_generators/PointsMeshGenerators.cs
+++ b/mesh_generators/PointsMeshGenerators.cs
@@ -22,7 +22,7 @@ namespace g3
             WantUVs = false;
         }
 
-        public override MeshGenerator Generate(int maxDegreeOfParallelism)
+        public override MeshGenerator Generate()
         {
             int N = (PointIndicesCount == -1) ? PointIndices.Count() : PointIndicesCount;
 
@@ -58,15 +58,14 @@ namespace g3
         /// </summary>
         public static DMesh3 Generate(IList<int> indices,
             Func<int, Vector3d> PointF, Func<int, Vector3d> NormalF,
-            double radius,
-            int maxDegreeOfParallelism)
+            double radius)
         {
             var gen = new PointSplatsGenerator() {
                 PointIndices = indices,
                 PointIndicesCount = indices.Count,
                 PointF = PointF, NormalF = NormalF, Radius = radius
             };
-            return gen.Generate(maxDegreeOfParallelism).MakeDMesh();
+            return gen.Generate().MakeDMesh();
         }
 
     }

--- a/mesh_generators/RevolveGenerator.cs
+++ b/mesh_generators/RevolveGenerator.cs
@@ -18,7 +18,7 @@ namespace g3
         public int startCapCenterIndex = -1;
         public int endCapCenterIndex = -1;
 
-        public override MeshGenerator Generate(int maxDegreeOfParallelism)
+        public override MeshGenerator Generate()
         {
             int nRings = Curve.Length;
             int nRingSize = (NoSharedVertices) ? Slices + 1 : Slices;
@@ -172,7 +172,7 @@ namespace g3
         public int startCapCenterIndex = -1;
         public int endCapCenterIndex = -1;
 
-        public override MeshGenerator Generate(int maxDegreeOfParallelism)
+        public override MeshGenerator Generate()
         {
             double tCurveLen = CurveUtils.ArcLength(Curve);
             SampledArcLengthParam pAxis = new SampledArcLengthParam(Axis, Axis.Length);

--- a/mesh_generators/SphereGenerators.cs
+++ b/mesh_generators/SphereGenerators.cs
@@ -23,9 +23,9 @@ namespace g3
         }
         NormalizationTypes NormalizeType = NormalizationTypes.CubeMapping;
 
-        public override MeshGenerator Generate(int maxDegreeOfParallelism)
+        public override MeshGenerator Generate()
         {
-            base.Generate(maxDegreeOfParallelism);
+            base.Generate();
             for ( int i = 0; i < vertices.Count; ++i ) {
                 Vector3d v = vertices[i] - Box.Center;
                 if (NormalizeType == NormalizationTypes.CubeMapping) {

--- a/mesh_generators/TriangulatedPolygonGenerator.cs
+++ b/mesh_generators/TriangulatedPolygonGenerator.cs
@@ -16,9 +16,9 @@ namespace g3
 		public int Subdivisions = 1;
         public MeshInsertPolygon Insert;
 
-        override public MeshGenerator Generate(int maxDegreeOfParallelism)
+        override public MeshGenerator Generate()
         {
-            DMesh3 base_mesh = ComputeResult(maxDegreeOfParallelism, out Insert);
+            DMesh3 base_mesh = ComputeResult(out Insert);
 
             DMesh3 compact = new DMesh3(base_mesh, true);
 
@@ -48,7 +48,7 @@ namespace g3
         /// coming back than we get by using Generate() api. Note that resulting
         /// mesh is *not* compacted.
         /// </summary>
-        public DMesh3 ComputeResult(int maxDegreeOfParallelism, out MeshInsertPolygon insertion)
+        public DMesh3 ComputeResult(out MeshInsertPolygon insertion)
         {
             AxisAlignedBox2d bounds = Polygon.Bounds;
             double padding = 0.1 * bounds.DiagonalLength;
@@ -62,7 +62,7 @@ namespace g3
 			rectgen.IndicesMap = new Index2i(1, 2);
 			rectgen.UVMode = UVMode;
 			rectgen.Clockwise = true;   // MeshPolygonInserter assumes mesh faces are CW? (except code says CCW...)
-			rectgen.Generate(maxDegreeOfParallelism);
+			rectgen.Generate();
 			DMesh3 base_mesh = new DMesh3();
 			rectgen.MakeMesh(base_mesh);
 
@@ -76,7 +76,7 @@ namespace g3
             
             insertion = insert;
             
-            bool bOK = insert.Insert(maxDegreeOfParallelism);
+            bool bOK = insert.Insert();
             if (!bOK)
                 throw new Exception("TriangulatedPolygonGenerator: failed to Insert()");
 

--- a/mesh_ops/AutoHoleFill.cs
+++ b/mesh_ops/AutoHoleFill.cs
@@ -62,7 +62,7 @@ namespace gs
             else if (type == UseFillType.MinimalFill)
                 bResult = fill_minimal(maxDegreeOfParallelism);
             else if (type == UseFillType.PlanarSpansFill)
-                bResult = fill_planar_spans(maxDegreeOfParallelism);
+                bResult = fill_planar_spans();
             else
                 bResult = fill_smooth(maxDegreeOfParallelism);
 
@@ -163,7 +163,7 @@ namespace gs
         ///    2) 
         /// 
         /// </summary>
-        bool fill_planar_spans(int maxDegreeOfParallelism)
+        bool fill_planar_spans()
         {
             Dictionary<Vector3d, List<EdgeSpan>> span_sets = find_coplanar_span_sets(Mesh, FillLoop);
 
@@ -179,7 +179,7 @@ namespace gs
                             PlanarSpansFiller filler = new PlanarSpansFiller(Mesh, subset);
                             filler.FillTargetEdgeLen = TargetEdgeLength;
                             filler.SetPlane(pos, normal);
-                            filler.Fill(maxDegreeOfParallelism);
+                            filler.Fill();
                         }
                     }
 
@@ -187,7 +187,7 @@ namespace gs
                     PlanarSpansFiller filler = new PlanarSpansFiller(Mesh, spans);
                     filler.FillTargetEdgeLen = TargetEdgeLength;
                     filler.SetPlane(pos, normal);
-                    filler.Fill(maxDegreeOfParallelism);
+                    filler.Fill();
                 }
             }
 

--- a/mesh_ops/MeshExtrudeFaces.cs
+++ b/mesh_ops/MeshExtrudeFaces.cs
@@ -75,7 +75,7 @@ namespace g3
         /// However changes are not backed out, so if false is returned, input Mesh is in 
         /// undefined state (generally means there are some holes)
         /// </summary>
-        public virtual bool Extrude(int maxDegreeOfParallelism)
+        public virtual bool Extrude()
         {
             MeshEditor editor = new MeshEditor(Mesh);
 
@@ -85,7 +85,7 @@ namespace g3
             bool bHaveNormals = Mesh.HasVertexNormals;
             if (!bHaveNormals) {
                 normals = new MeshNormals(Mesh);
-                normals.Compute(maxDegreeOfParallelism);
+                normals.Compute();
             }
 
             ExtrudeVertices = new MeshVertexSelection(Mesh);

--- a/mesh_ops/MeshExtrudeMesh.cs
+++ b/mesh_ops/MeshExtrudeMesh.cs
@@ -56,13 +56,13 @@ namespace g3
         }
 
 
-        public virtual bool Extrude(int maxDegreeOfParallelism)
+        public virtual bool Extrude()
         {
             MeshNormals normals = null;
             bool bHaveNormals = Mesh.HasVertexNormals;
             if (!bHaveNormals) {
                 normals = new MeshNormals(Mesh);
-                normals.Compute(maxDegreeOfParallelism);
+                normals.Compute();
             }
 
             InitialLoops = new MeshBoundaryLoops(Mesh);

--- a/mesh_ops/MeshInsertPolygon.cs
+++ b/mesh_ops/MeshInsertPolygon.cs
@@ -22,11 +22,11 @@ namespace g3
         public HashSet<int> InsertedPolygonEdges;
         public MeshFaceSelection InteriorTriangles;
 
-        public bool Insert(int maxDegreeOfParallelism)
+        public bool Insert()
         {
             OuterInsert = new MeshInsertUVPolyCurve(Mesh, Polygon.Outer);
             Util.gDevAssert(OuterInsert.Validate() == ValidationStatus.Ok);
-            bool outerApplyOK = OuterInsert.Apply(maxDegreeOfParallelism);
+            bool outerApplyOK = OuterInsert.Apply();
             if (outerApplyOK == false || OuterInsert.Loops.Count == 0)
                 return false;
             if (SimplifyInsertion)
@@ -36,7 +36,7 @@ namespace g3
             for (int hi = 0; hi < Polygon.Holes.Count; ++hi) {
                 MeshInsertUVPolyCurve insert = new MeshInsertUVPolyCurve(Mesh, Polygon.Holes[hi]);
                 Util.gDevAssert(insert.Validate() == ValidationStatus.Ok);
-                insert.Apply(maxDegreeOfParallelism);
+                insert.Apply();
                 if (SimplifyInsertion)
                     insert.Simplify();
                 HoleInserts.Add(insert);

--- a/mesh_ops/MeshInsertProjectedPolygon.cs
+++ b/mesh_ops/MeshInsertProjectedPolygon.cs
@@ -122,7 +122,7 @@ namespace gs
         }
 
 
-        public bool Insert(int maxDegreeOfParallelism)
+        public bool Insert()
         {
             Func<int, bool> is_contained_v = (vid) => {
                 Vector3d v = Mesh.GetVertex(vid);
@@ -179,7 +179,7 @@ namespace gs
 
             MeshInsertUVPolyCurve insertUV = new MeshInsertUVPolyCurve(roiMesh, Polygon);
             //insertUV.Validate()
-            bool bOK = insertUV.Apply(maxDegreeOfParallelism);
+            bool bOK = insertUV.Apply();
             if (!bOK)
                 throw new Exception("insertUV.Apply() failed");
 

--- a/mesh_ops/MeshMeshCut.cs
+++ b/mesh_ops/MeshMeshCut.cs
@@ -82,12 +82,12 @@ namespace g3
             }
         }
 
-        public void AppendSegments(double r, int maxDegreeOfParallelism)
+        public void AppendSegments(double r)
         {
             foreach ( var seg in Segments ) {
                 Segment3d s = new Segment3d(seg.v0.v, seg.v1.v);
                 if ( Target.FindEdge(seg.v0.vtx_id, seg.v1.vtx_id) == DMesh3.InvalidID )
-                    MeshEditor.AppendLine(Target, s, (float)r, maxDegreeOfParallelism);
+                    MeshEditor.AppendLine(Target, s, (float)r);
             }
         }
 
@@ -468,7 +468,7 @@ namespace g3
             path.AppendVertex(p0); path.AppendVertex(p1);
 
             MeshInsertUVPolyCurve insert = new MeshInsertUVPolyCurve(mesh, path);
-            insert.Apply(maxDegreeOfParallelism);
+            insert.Apply();
 
             MeshVertexSelection cutVerts = new MeshVertexSelection(mesh);
             cutVerts.SelectEdgeVertices(insert.OnCutEdges);

--- a/mesh_ops/MeshTopology.cs
+++ b/mesh_ops/MeshTopology.cs
@@ -201,7 +201,7 @@ namespace gs
 
 
 
-        public DMesh3 MakeElementsMesh(Polygon2d spanProfile, Polygon2d loopProfile, int maxDegreeOfParallelism)
+        public DMesh3 MakeElementsMesh(Polygon2d spanProfile, Polygon2d loopProfile)
         {
             DMesh3 result = new DMesh3();
             validate_topology();
@@ -209,13 +209,13 @@ namespace gs
             foreach (EdgeSpan span in Spans) {
                 DCurve3 curve = span.ToCurve(Mesh);
                 TubeGenerator tubegen = new TubeGenerator(curve, spanProfile);
-                MeshEditor.Append(result, tubegen.Generate(maxDegreeOfParallelism).MakeDMesh());
+                MeshEditor.Append(result, tubegen.Generate().MakeDMesh());
             }
 
             foreach (EdgeLoop loop in Loops) {
                 DCurve3 curve = loop.ToCurve(Mesh);
                 TubeGenerator tubegen = new TubeGenerator(curve, loopProfile);
-                MeshEditor.Append(result, tubegen.Generate(maxDegreeOfParallelism).MakeDMesh());
+                MeshEditor.Append(result, tubegen.Generate().MakeDMesh());
             }
 
             return result;

--- a/mesh_ops/PlanarHoleFiller.cs
+++ b/mesh_ops/PlanarHoleFiller.cs
@@ -166,7 +166,7 @@ namespace g3
                         EdgeVertices = nDivisions
                     };
                 }
-                DMesh3 FillMesh = meshgen.Generate(maxDegreeOfParallelism).MakeDMesh();
+                DMesh3 FillMesh = meshgen.Generate().MakeDMesh();
                 FillMesh.ReverseOrientation();   // why?!?
 
                 // convenient list
@@ -182,7 +182,7 @@ namespace g3
                     ValidationStatus status = insert.Validate(MathUtil.ZeroTolerancef * scale);
                     bool failed = true;
                     if (status == ValidationStatus.Ok) {
-                        if (insert.Apply(maxDegreeOfParallelism)) {
+                        if (insert.Apply()) {
                             insert.Simplify();
                             polyVertices[pi] = insert.CurveVertices;
                             failed = (insert.Loops.Count != 1) ||

--- a/mesh_ops/PlanarSpansFiller.cs
+++ b/mesh_ops/PlanarSpansFiller.cs
@@ -69,7 +69,7 @@ namespace g3
         }
 
 
-        public bool Fill(int maxDegreeOfParallelism)
+        public bool Fill()
         {
             compute_polygon();
 
@@ -101,7 +101,7 @@ namespace g3
                     EdgeVertices = nDivisions
                 };
             }
-            DMesh3 FillMesh = meshgen.Generate(maxDegreeOfParallelism).MakeDMesh();
+            DMesh3 FillMesh = meshgen.Generate().MakeDMesh();
             FillMesh.ReverseOrientation();   // why?!?
 
             int[] polyVertices = null;
@@ -111,7 +111,7 @@ namespace g3
             ValidationStatus status = insert.Validate(MathUtil.ZeroTolerancef * scale);
             bool failed = true;
             if (status == ValidationStatus.Ok) {
-                if (insert.Apply(maxDegreeOfParallelism)) {
+                if (insert.Apply()) {
                     insert.Simplify();
                     polyVertices = insert.CurveVertices;
                     failed = false;

--- a/mesh_ops/RemoveOccludedTriangles.cs
+++ b/mesh_ops/RemoveOccludedTriangles.cs
@@ -134,7 +134,7 @@ namespace gs
                 MeshNormals normals = null;
                 if (Mesh.HasVertexNormals == false) {
                     normals = new MeshNormals(Mesh);
-                    normals.Compute(maxDegreeOfParallelism);
+                    normals.Compute();
                 }
 
                 gParallel.ForEach(Mesh.VertexIndices(), (vid) => {

--- a/mesh_ops/SmoothedHoleFill.cs
+++ b/mesh_ops/SmoothedHoleFill.cs
@@ -127,7 +127,7 @@ namespace gs
                 extrude.ExtrudedPositionF = (v, n, vid) => {
                     return v + OffsetDistance * OffsetDirection;
                 };
-                if (!extrude.Extrude(maxDegreeOfParallelism))
+                if (!extrude.Extrude())
                     return false;
                 tris.Select(extrude.JoinTriangles);
             }

--- a/test/StandardMeshReaderTests.cs
+++ b/test/StandardMeshReaderTests.cs
@@ -11,11 +11,10 @@ namespace geometry3sharp.Tests
 {
     public class StandardMeshReaderTests
     {
-        private static readonly int MaxDegreeOfParallelism = Environment.ProcessorCount;
         private static string ModelsDirectoryPath => Path.Combine("..", "..", "..", "models");
         private static string BoxPathWithoutExtension => Path.Combine(ModelsDirectoryPath, "box");
         private static readonly Lazy<DMesh3> BoxMesh =
-            new Lazy<DMesh3>(() => new TrivialBox3Generator().Generate(MaxDegreeOfParallelism).MakeDMesh());
+            new Lazy<DMesh3>(() => new TrivialBox3Generator().Generate().MakeDMesh());
 
         [Fact(Skip = "Use this method to regenerate the box")]
         public void WriteAllFiles()


### PR DESCRIPTION
## Problem

It was noticed that some parallel g3 code isn't worth being parallel. The best example is `MeshNormals.QuickCompute`. The benchmark results comparing it with a sequential `MeshNormalsCalculator` are below

Code

```csharp
using BenchmarkDotNet.Attributes;
using g3;
using SoftSmile.Vision.Common.MeshOps;
using SoftSmile.Vision.Draco;

namespace SoftSmile.Vision.Algorithms.Benchmark.Spatial;

public class MeshNormalsBenchmark
{
    private readonly DMesh3 _mesh;

    public MeshNormalsBenchmark()
    {
        _mesh = new DracoDecoder()
            .Decode(
                File.ReadAllBytes(@"C:\Users\artem\Downloads\1.7. cnd collisions\Set.LocalDevVersion\raw_jaw_Lower_drc.drc"));
    }

    [Benchmark(Baseline = true)]
    public void Parallel()
    {
        MeshNormals.QuickCompute(_mesh);
    }

    [Benchmark()]
    public void Sequential()
    {
        MeshNormalsCalculator.ComputeNormals(_mesh);
    }
}
```

My PC

```
|     Method |      Mean |     Error |    StdDev | Ratio | RatioSD |
|----------- |----------:|----------:|----------:|------:|--------:|
|   Parallel | 40.210 ms | 2.3897 ms | 6.9329 ms |  1.00 |    0.00 |
| Sequential |  8.079 ms | 0.0423 ms | 0.0396 ms |  0.21 |    0.04 |
```

@myroslav-valovyi results

![image](https://github.com/SoftSmile-Inc/geometry3Sharp/assets/13029907/7f7b734c-f6f8-4ef5-9028-3b9c801e4357)

The reasons for such results are obvious:

1. The threads are spending too much time synchronizing with each other, compared with the computational time of the `Cross` and `Area` functions
2. The interface access is far more expensive than direct class property calls.

## Solution

There are a few potentially incorrect places like that. This request tries to clean ineffective parallelism in some g3 functions. As a result, we would remove `maxDegreeOfParallelism` from obscure functions like box mesh generation. 

Candidates are

1. `MeshNormals`, shown above
2. `MeshInsertUVPolyCurve`. WhichSide is an almost free operation for doing it parallelly
3. `MeshPlaneCut`. The same as `2`