### PR TITLE
stability fix for LaplacianMeshSmoother

### DIFF
--- a/mesh_ops/LaplacianMeshSmoother.cs
+++ b/mesh_ops/LaplacianMeshSmoother.cs
@@ -402,7 +402,7 @@ namespace g3
                     constrained.Add(sub_vid);
             }
 
-            if (constrained.Count > 0) {
+            if (constrained != null && constrained.Count > 0) {
                 w = Math.Sqrt(w);
                 for (int k = 0; k < nConstrainLoops; ++k) {
                     HashSet<int> next_layer = new HashSet<int>();


### PR DESCRIPTION
stability fix for LaplacianMeshSmoother: it failed in LaplacianMeshSmoother.RegionSmooth when the input mesh was Closed, and nIncludeExteriorRings was big enough to include all the remaining (not smoothed) triangles in the mesh.