### PR TITLE
VIS-7230 - limit endless loop in LaplacianMeshSmoother; correctly transfer MaxDegreeOfParallelism argument through code tree

### DIFF
--- a/mesh_ops/LaplacianMeshSmoother.cs
+++ b/mesh_ops/LaplacianMeshSmoother.cs
@@ -198,7 +198,7 @@ namespace g3
 
 
         // Result must be as large as Mesh.MaxVertexID
-        public bool SolveMultipleCG(Vector3d[] Result, int maxDegreeOfParallelism, int maxIterations = int.MaxValue)
+        public bool SolveMultipleCG(Vector3d[] Result, int maxIterations, int maxDegreeOfParallelism)
         {
             if (WeightsM == null)
                 Initialize(maxDegreeOfParallelism);       // force initialize...
@@ -261,7 +261,7 @@ namespace g3
 
 
         // Result must be as large as Mesh.MaxVertexID
-        public bool SolveMultipleRHS(Vector3d[] Result, int maxDegreeOfParallelism, int maxIterations = int.MaxValue)
+        public bool SolveMultipleRHS(Vector3d[] Result, int maxIterations, int maxDegreeOfParallelism)
         {
             if (WeightsM == null)
                 Initialize(maxDegreeOfParallelism);       // force initialize...
@@ -317,23 +317,23 @@ namespace g3
         }
 
 
-        public bool Solve(Vector3d[] Result, int maxIterations = int.MaxValue)
+        public bool Solve(Vector3d[] Result, int maxIterations, int maxDegreeOfParallelism)
         {
             // for small problems, faster to use separate CGs?
             if ( Mesh.VertexCount < 10000 )
-                return SolveMultipleCG(Result, maxIterations);
+                return SolveMultipleCG(Result, maxIterations, maxDegreeOfParallelism);
             else
-                return SolveMultipleRHS(Result, maxIterations);
+                return SolveMultipleRHS(Result, maxIterations, maxDegreeOfParallelism);
         }
 
 
 
 
-        public bool SolveAndUpdateMesh(int maxIterations = int.MaxValue)
+        public bool SolveAndUpdateMesh(int maxIterations, int maxDegreeOfParallelism)
         {
             int N = Mesh.MaxVertexID;
             Vector3d[] Result = new Vector3d[N];
-            if ( Solve(Result, maxIterations) == false )
+            if ( Solve(Result, maxIterations, maxDegreeOfParallelism) == false )
                 return false;
             for (int i = 0; i < N; ++i ) {
                 if ( Mesh.IsVertex(i) ) {
@@ -357,6 +357,8 @@ namespace g3
             int nConstrainLoops, 
             int nIncludeExteriorRings,
             bool bPreserveExteriorRings,
+            int maxDegreeOfParallelism,
+            int maxIterations = int.MaxValue,
             double borderWeight = 10.0, double interiorWeight = 0.0)
         {
             HashSet<int> fixedVerts = new HashSet<int>();
@@ -435,10 +437,8 @@ namespace g3
                 }
             }
 
-            smoother.SolveAndUpdateMesh();
+            smoother.SolveAndUpdateMesh(maxIterations, maxDegreeOfParallelism);
             region.BackPropropagateVertices(true);
         }
-
-
     }
 }

--- a/mesh_ops/SmoothedHoleFill.cs
+++ b/mesh_ops/SmoothedHoleFill.cs
@@ -179,7 +179,7 @@ namespace gs
         void smooth_and_remesh_preserve(MeshFaceSelection tris, bool bFinal, int maxDegreeOfParallelism)
         {
             if (EnableLaplacianSmooth) {
-                LaplacianMeshSmoother.RegionSmooth(Mesh, tris, 2, 2, true);
+                LaplacianMeshSmoother.RegionSmooth(Mesh, tris, 2, 2, true, maxDegreeOfParallelism, maxIterations: 1000); // limit 1000 iterations to prevent endless loop
             }
 
             if (RemeshAfterSmooth) {
@@ -206,7 +206,7 @@ namespace gs
         void smooth_and_remesh(MeshFaceSelection tris, int maxDegreeOfParallelism)
         {
             if (EnableLaplacianSmooth) {
-                LaplacianMeshSmoother.RegionSmooth(Mesh, tris, 2, 2, false);
+                LaplacianMeshSmoother.RegionSmooth(Mesh, tris, 2, 2, false, maxDegreeOfParallelism, maxIterations: 1000); // limit 1000 iterations to prevent endless loop
             }
 
             if (RemeshAfterSmooth) {


### PR DESCRIPTION
1. Prevent endless loop in LaplacianMeshSmoother - specified MaxIterations explicitly. 
2. Correctly transfer MaxDegreeOfParallelism argument through code tree. Previously there was a mistake when MaxIterations argument value was mistakenly passed into MaxDegreeOfParallelism argument.
