### PR TITLE
fixed DynamicPriorityQueue behavior after it has got .Clear(bFreeMemory: false)

### DIFF
--- a/core/DynamicPriorityQueue.cs
+++ b/core/DynamicPriorityQueue.cs
@@ -88,7 +88,8 @@ namespace g3
         /// constant-time check to see if node is already in queue
         /// </summary>
         public bool Contains(T node) {
-            return (nodes[node.index] == node);
+            return (node.index <= num_nodes && // 'num_nodes' is actually the Inclusive boundary (by some reason)
+                    nodes[node.index] == node);
         }
 
 


### PR DESCRIPTION
fixed DynamicPriorityQueue behavior after it has go called .Clear(bFreeMemory: false)